### PR TITLE
Support formatting of specific files via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ main(args) async {
   // Configure the port on which examples should be served.
   config.examples.port = 9000;
 
-  // Define the directories to include when running the
+  // Define the paths to include when running the
   // Dart formatter.
-  config.format.directories = ['lib/', 'test/', 'tool/'];
+  config.format.paths = ['lib/', 'test/', 'tool/'];
 
   // Define overrides for local task discovery
   config.local
@@ -488,10 +488,10 @@ object.
             <td>Dry-run; checks if formatter needs to be run and sets exit code accordingly.</td>
         </tr>
         <tr>
-            <td><code>directories</code></td>
+            <td><code>paths</code></td>
             <td><code>List&lt;String&gt;</code></td>
             <td><code>['lib/']</code></td>
-            <td>Directories to run the formatter on. All files (any depth) in the given directories will be formatted.</td>
+            <td>Files/directories to run the formatter on. All files (any depth) in the given directories will be formatted.</td>
         </tr>
     </tbody>
 </table>

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -101,7 +101,7 @@ String _generateUsage([String task]) {
   u.writeln();
 
   if (task != null && _cliTasks.containsKey(task)) {
-    u.writeln('Usage: pub run dart_dev $task [options]');
+    u.writeln('Usage: pub run dart_dev ${_cliTasks[task].usage}');
     u.writeln();
     u.writeln(_cliTasks[task].argParser.usage);
   } else {

--- a/lib/src/tasks/cli.dart
+++ b/lib/src/tasks/cli.dart
@@ -31,6 +31,7 @@ abstract class TaskCli {
 
   ArgParser get argParser;
   String get command;
+  String get usage => '$command [options]';
 
   Future<CliResult> run(ArgResults parsedArgs, {bool color: true});
 }

--- a/lib/src/tasks/format/api.dart
+++ b/lib/src/tasks/format/api.dart
@@ -23,12 +23,18 @@ import 'package:dart_dev/util.dart' show TaskProcess;
 import 'package:dart_dev/src/tasks/format/config.dart';
 import 'package:dart_dev/src/tasks/task.dart';
 
+// ignore: deprecated_member_use
+/// [directories] is deprecated; use [paths] instead.
 FormatTask format({
   bool check: defaultCheck,
-  List<String> directories: defaultDirectories,
   List<String> exclude: defaultExclude,
   int lineLength: defaultLineLength,
+  List<String> paths: defaultPaths,
+  @Deprecated('2.0.0') List<String> directories,
 }) {
+  // ignore: deprecated_member_use
+  if (directories != null) paths = directories;
+
   var executable = 'pub';
   var args = ['run', 'dart_style:format'];
 
@@ -40,7 +46,7 @@ FormatTask format({
     args.add('-w');
   }
 
-  var filesToFormat = getFilesToFormat(paths: directories, exclude: exclude);
+  var filesToFormat = getFilesToFormat(paths: paths, exclude: exclude);
 
   args.addAll(filesToFormat.files);
 
@@ -80,7 +86,7 @@ FormatTask format({
   return task;
 }
 
-/// Returns a set of files to be formatted, with [exclude] excluded.
+/// Returns a set of files within [paths] to be formatted, with [exclude] excluded.
 ///
 /// [paths] can contain both files and directories. Files within directories
 /// will be processed recursively, ignoring symlinks.
@@ -88,9 +94,9 @@ FormatTask format({
 /// If [exclude] is not empty, the return value will include [paths], expanded
 /// to all matching files. Otherwise, it will not be expanded.
 ///
-/// To force expansion , set [alwaysExpand] to `true`.
+/// To force expansion, set [alwaysExpand] to `true`.
 FilesToFormat getFilesToFormat({
-  List<String> paths: defaultDirectories,
+  List<String> paths: defaultPaths,
   List<String> exclude: defaultExclude,
   bool alwaysExpand: false,
 }) {

--- a/lib/src/tasks/format/api.dart
+++ b/lib/src/tasks/format/api.dart
@@ -40,8 +40,7 @@ FormatTask format({
     args.add('-w');
   }
 
-  var filesToFormat =
-      getFilesToFormat(directories: directories, exclude: exclude);
+  var filesToFormat = getFilesToFormat(paths: directories, exclude: exclude);
 
   args.addAll(filesToFormat.files);
 
@@ -81,34 +80,38 @@ FormatTask format({
   return task;
 }
 
-/// Returns a set of files/directories within [directories] to be formatted,
-/// with [exclude] excluded.
+/// Returns a set of files to be formatted, with [exclude] excluded.
 ///
-/// If [exclude] is not empty, then [directories] will be expanded recursively
-/// (ignoring symlinks) to all of its files. Otherwise, it will not be expanded.
+/// [paths] can contain both files and directories. Files within directories
+/// will be processed recursively, ignoring symlinks.
 ///
-/// To force expansion of [directories], set [alwaysExpand] to `true`.
+/// If [exclude] is not empty, the return value will include [paths], expanded
+/// to all matching files. Otherwise, it will not be expanded.
+///
+/// To force expansion , set [alwaysExpand] to `true`.
 FilesToFormat getFilesToFormat({
-  List<String> directories: defaultDirectories,
+  List<String> paths: defaultDirectories,
   List<String> exclude: defaultExclude,
   bool alwaysExpand: false,
 }) {
   var filesToFormat = new FilesToFormat();
 
   if (exclude.isEmpty && !alwaysExpand) {
-    // If no files are excluded, we can use the directories and let the dart
+    // If no files are excluded, we can use the paths and let the dart
     // formatter expand the files.
-    filesToFormat.files.addAll(directories);
+    filesToFormat.files.addAll(paths);
   } else {
     // Convert exclude paths to relative paths, so they can be efficiently
     // compared to the files we're listing.
     exclude = exclude.map(path.relative).toList();
 
-    // Build the list of files by expanding the given directories, looking for
+    // Build the list of files by expanding the given paths, looking for
     // all .dart files that don't match any excluded path.
-    for (var p in directories) {
-      Directory dir = new Directory(p);
-      var files = dir.listSync(recursive: true, followLinks: false);
+    for (var p in paths) {
+      List<FileSystemEntity> files = FileSystemEntity.isFileSync(p)
+          ? [new File(p)]
+          : new Directory(p).listSync(recursive: true, followLinks: false);
+
       for (FileSystemEntity entity in files) {
         // Skip directories and links.
         if (entity is! File) continue;

--- a/lib/src/tasks/format/cli.dart
+++ b/lib/src/tasks/format/cli.dart
@@ -54,9 +54,8 @@ class FormatCli extends TaskCli {
     }
 
     bool check = TaskCli.valueOf('check', parsedArgs, config.format.check);
-    List<String> paths = parsedArgs.rest.isNotEmpty
-        ? parsedArgs.rest
-        : config.format.directories;
+    List<String> paths =
+        parsedArgs.rest.isNotEmpty ? parsedArgs.rest : config.format.paths;
 
     List<String> exclude = config.format.exclude;
     var lineLength =
@@ -67,7 +66,7 @@ class FormatCli extends TaskCli {
 
     FormatTask task = format(
       check: check,
-      directories: paths,
+      paths: paths,
       exclude: exclude,
       lineLength: lineLength,
     );

--- a/lib/src/tasks/format/cli.dart
+++ b/lib/src/tasks/format/cli.dart
@@ -38,6 +38,8 @@ class FormatCli extends TaskCli {
 
   final String command = 'format';
 
+  String get usage => '${super.usage} [files or directories...]';
+
   Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
     try {
       if (!platform_util.hasImmediateDependency('dart_style'))

--- a/lib/src/tasks/format/cli.dart
+++ b/lib/src/tasks/format/cli.dart
@@ -52,7 +52,10 @@ class FormatCli extends TaskCli {
     }
 
     bool check = TaskCli.valueOf('check', parsedArgs, config.format.check);
-    List<String> directories = config.format.directories;
+    List<String> paths = parsedArgs.rest.isNotEmpty
+        ? parsedArgs.rest
+        : config.format.directories;
+
     List<String> exclude = config.format.exclude;
     var lineLength =
         TaskCli.valueOf('line-length', parsedArgs, config.format.lineLength);
@@ -61,10 +64,11 @@ class FormatCli extends TaskCli {
     }
 
     FormatTask task = format(
-        check: check,
-        directories: directories,
-        exclude: exclude,
-        lineLength: lineLength);
+      check: check,
+      directories: paths,
+      exclude: exclude,
+      lineLength: lineLength,
+    );
     reporter.logGroup(task.formatterCommand,
         outputStream: task.formatterOutput);
     await task.done;

--- a/lib/src/tasks/format/config.dart
+++ b/lib/src/tasks/format/config.dart
@@ -17,19 +17,31 @@ library dart_dev.src.tasks.format.config;
 import 'package:dart_dev/src/tasks/config.dart';
 
 const bool defaultCheck = false;
-const List<String> defaultDirectories = const ['lib/'];
+const List<String> defaultPaths = const ['lib/'];
 const List<String> defaultExclude = const [];
 const int defaultLineLength = 80;
 
+/// Deprecated; use [defaultPaths] instead.
+@Deprecated('2.0.0')
+const List<String> defaultDirectories = defaultPaths;
+
 class FormatConfig extends TaskConfig {
   bool check = defaultCheck;
-  List<String> directories = defaultDirectories;
+  List<String> paths = defaultPaths;
   List<String> exclude = defaultExclude;
   int lineLength = defaultLineLength;
 
+  /// Deprecated; use [paths] instead.
+  @Deprecated('2.0.0')
+  List<String> get directories => paths;
+
+  /// Deprecated; use [paths] instead.
+  @Deprecated('2.0.0')
+  set directories(List<String> value) => paths = value;
+
   Map<String, dynamic> toJson() => {
         'check': check,
-        'directories': directories,
+        'paths': paths,
         'exclude': exclude,
         'lineLength': lineLength,
       };

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -65,6 +65,8 @@ class TestCli extends TaskCli {
 
   final String command = 'test';
 
+  String get usage => '${super.usage} [files or directories...]';
+
   bool isExplicitlyFalse(bool value) {
     return value != null && value == false;
   }

--- a/test/integration/format_test.dart
+++ b/test/integration/format_test.dart
@@ -34,11 +34,18 @@ const String projectWithoutDartStyle = 'test_fixtures/format/no_dart_style';
 ///
 /// If [check] is false, an actual formatting run is run. Returns true if
 /// formatting was successful, false otherwise.
-Future<bool> formatProject(String projectPath, {bool check: false}) async {
+Future<bool> formatProject(
+  String projectPath, {
+  bool check: false,
+  Iterable additionalArgs: const [],
+}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
   var args = ['run', 'dart_dev', 'format'];
   if (check) {
     args.add('--check');
+  }
+  if (additionalArgs != null) {
+    args.addAll(additionalArgs);
   }
   TaskProcess process =
       new TaskProcess('pub', args, workingDirectory: projectPath);
@@ -67,23 +74,67 @@ void main() {
       expect(contentsBefore, equals(contentsAfter));
     });
 
-    test('should format an ill-formatted project', () async {
-      // Copy the ill-formatted project fixture to a temporary directory for
-      // testing purposes (necessary since formatter will make changes).
-      String testProject = '${projectWithChangesNeeded}_temp';
-      Directory temp = new Directory(testProject);
-      copyDirectory(new Directory(projectWithChangesNeeded), temp);
+    group('should format an ill-formatted project', () {
+      const String testProject = '${projectWithChangesNeeded}_temp';
 
-      File dirtyFile = new File('$testProject/lib/main.dart');
-      File cleanFile = new File('$projectWithNoChangesNeeded/lib/main.dart');
-      String contentsBefore = dirtyFile.readAsStringSync();
-      expect(await formatProject(testProject), isTrue);
-      String contentsAfter = dirtyFile.readAsStringSync();
-      expect(contentsBefore, isNot(equals(contentsAfter)));
-      expect(contentsAfter, equals(cleanFile.readAsStringSync()));
+      const allFiles = const [
+        'lib/library_1.dart',
+        'lib/library_2.dart',
+      ];
 
-      // Clean up the temporary test project created for this test case.
-      temp.deleteSync(recursive: true);
+      Directory temp;
+      setUp(() {
+        // Copy the ill-formatted project fixture to a temporary directory for
+        // testing purposes (necessary since formatter will make changes).
+        temp = new Directory(testProject);
+        copyDirectory(new Directory(projectWithChangesNeeded), temp);
+      });
+
+      tearDown(() {
+        // Clean up the temporary test project created for this test case.
+        temp.deleteSync(recursive: true);
+      });
+
+      Map<String, String> getAllFilesContents() => new Map.fromIterable(
+          allFiles,
+          value: (file) => new File('$testProject/$file').readAsStringSync());
+
+      test('should format an ill-formatted project', () async {
+        var contentsBefore = getAllFilesContents();
+        expect(await formatProject(testProject), isTrue);
+        var contentsAfter = getAllFilesContents();
+
+        for (var file in allFiles) {
+          expect(contentsBefore[file], isNot(contentsAfter[file]),
+              reason: '$file should have been formatted');
+        }
+      });
+
+      test(
+          'should format only the paths specified as arguments'
+          ' within an ill-formatted project', () async {
+        // It's important that these are relative paths to the project root
+        const expectedModifiedFiles = const [
+          'lib/library_1.dart',
+        ];
+
+        var contentsBefore = getAllFilesContents();
+        expect(
+            await formatProject(testProject,
+                additionalArgs: expectedModifiedFiles),
+            isTrue);
+        var contentsAfter = getAllFilesContents();
+
+        for (var file in allFiles) {
+          if (expectedModifiedFiles.contains(file)) {
+            expect(contentsBefore[file], isNot(contentsAfter[file]),
+                reason: '$file should have been formatted');
+          } else {
+            expect(contentsBefore[file], contentsAfter[file],
+                reason: '$file should not have been formatted');
+          }
+        }
+      });
     });
 
     test('should warn if "dart_style" is not an immediate dependency',

--- a/test/integration/format_test.dart
+++ b/test/integration/format_test.dart
@@ -36,8 +36,8 @@ const String projectWithoutDartStyle = 'test_fixtures/format/no_dart_style';
 /// formatting was successful, false otherwise.
 Future<bool> formatProject(
   String projectPath, {
-  bool check: false,
   Iterable additionalArgs: const [],
+  bool check: false,
 }) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
   var args = ['run', 'dart_dev', 'format'];

--- a/test_fixtures/format/changes_needed/lib/library_1.dart
+++ b/test_fixtures/format/changes_needed/lib/library_1.dart
@@ -1,5 +1,3 @@
-library main;
-
 List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
 
 void doStuff(

--- a/test_fixtures/format/changes_needed/lib/library_2.dart
+++ b/test_fixtures/format/changes_needed/lib/library_2.dart
@@ -1,0 +1,7 @@
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/inclusions/lib/included.dart
+++ b/test_fixtures/format/inclusions/lib/included.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/inclusions/lib/included_dir_1/inside_included_dir.dart
+++ b/test_fixtures/format/inclusions/lib/included_dir_1/inside_included_dir.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/inclusions/lib/included_dir_2/inside_included_dir.dart
+++ b/test_fixtures/format/inclusions/lib/included_dir_2/inside_included_dir.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/inclusions/lib/not_included.dart
+++ b/test_fixtures/format/inclusions/lib/not_included.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/inclusions/pubspec.yaml
+++ b/test_fixtures/format/inclusions/pubspec.yaml
@@ -1,0 +1,6 @@
+name: inclusions
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  dart_style: ">=0.1.8 <0.3.0"

--- a/test_fixtures/format/inclusions/tool/dev.dart
+++ b/test_fixtures/format/inclusions/tool/dev.dart
@@ -1,0 +1,13 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.format.paths = [
+    'lib/included.dart',
+    // test absent and present trailing slashes
+    'lib/included_dir_1',
+    'lib/included_dir_2/',
+  ];
+  await dev(args);
+}

--- a/test_fixtures/format/inclusions_deprecated/lib/included.dart
+++ b/test_fixtures/format/inclusions_deprecated/lib/included.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/inclusions_deprecated/lib/included_dir_1/inside_included_dir.dart
+++ b/test_fixtures/format/inclusions_deprecated/lib/included_dir_1/inside_included_dir.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/inclusions_deprecated/lib/included_dir_2/inside_included_dir.dart
+++ b/test_fixtures/format/inclusions_deprecated/lib/included_dir_2/inside_included_dir.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/inclusions_deprecated/lib/not_included.dart
+++ b/test_fixtures/format/inclusions_deprecated/lib/not_included.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/inclusions_deprecated/pubspec.yaml
+++ b/test_fixtures/format/inclusions_deprecated/pubspec.yaml
@@ -1,0 +1,6 @@
+name: inclusions_deprecated
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  dart_style: ">=0.1.8 <0.3.0"

--- a/test_fixtures/format/inclusions_deprecated/tool/dev.dart
+++ b/test_fixtures/format/inclusions_deprecated/tool/dev.dart
@@ -1,0 +1,14 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  // ignore: deprecated_member_use
+  config.format.directories = [
+    'lib/included.dart',
+    // test absent and present trailing slashes
+    'lib/included_dir_1',
+    'lib/included_dir_2/',
+  ];
+  await dev(args);
+}

--- a/test_fixtures/format/no_changes_needed/tool/dev.dart
+++ b/test_fixtures/format/no_changes_needed/tool/dev.dart
@@ -3,6 +3,6 @@ library tool.dev;
 import 'package:dart_dev/dart_dev.dart' show dev, config;
 
 main(List<String> args) async {
-  config.format.directories = ['bin/', 'lib/', 'tool/'];
+  config.format.paths = ['bin/', 'lib/', 'tool/'];
   await dev(args);
 }

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -22,7 +22,7 @@ main(args) async {
   config.copyLicense.directories = directories;
   config.coverage.reportOn = ['bin/', 'lib/'];
   config.format
-    ..directories = directories
+    ..paths = directories
     ..exclude = ['test/integration/generated_runner.dart'];
   config.genTestRunner.configs = [
     new TestRunnerConfig(directory: 'test/integration', env: Environment.vm)


### PR DESCRIPTION
## Ultimate problem:
https://github.com/Workiva/dart_dev/issues/51
> By default, the format task should use the project's configuration for files to format. But, we should also allow running the formatter on a specific file or set of files. This can be done by allowing additional args to the format CLI that override the default configuration.

I also wanted this behavior for my custom formatter task and needed to make some changes in dart_dev to support it, so I thought it'd only be fair to address that issue while I was at it 😃.

## Solution
- Allow specifying specific directories/files via CLI rest args
- Update formatter API to be able to take in specific files directly
- Add new `TaskCLI.usage` getter that allows for custom usage strings, to allow for indicating that `format`/`test` package accept rest args
    ```diff
     $ ddev format --help
     Standardized tooling for Dart projects.

    -Usage: pub run dart_dev format [options]
    +Usage: pub run dart_dev format [options] [files or directories...]
    ```
- Deprecate `FormatConfig.directories`, replacing it with and proxying it to `FormatConfig.paths` for clearer naming (since files can now be specified directly), and deprecate/proxy other `directories` named arguments accordingly
    - I'm on the fence as to whether this is warranted... Feel free to chime in.
- Update functional tests

## Testing
- Verify that formatting functional tests pass
- Verify `ddev format --help` looks good
- Verify `ddev test --help` looks good

## Areas of regression
- Formatter task
- `--help` flag
